### PR TITLE
Skip profit calculation if empty block requested

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1176,28 +1176,31 @@ func (w *worker) generateWork(params *generateParams) (*types.Block, error) {
 		return block, nil
 	}
 
-	if !params.noTxs {
-		if len(work.txs) == 0 {
-			return nil, errors.New("no proposer payment tx")
-		} else if len(work.receipts) == 0 {
-			return nil, errors.New("no proposer payment receipt")
-		}
-	
-		lastTx := work.txs[len(work.txs)-1]
-		receipt := work.receipts[len(work.receipts)-1]
-		if receipt.TxHash != lastTx.Hash() || receipt.Status != types.ReceiptStatusSuccessful {
-			log.Error("proposer payment not successful!", "lastTx", lastTx, "receipt", receipt)
-			return nil, errors.New("last transaction is not proposer payment")
-		}
-		lastTxTo := lastTx.To()
-		if lastTxTo == nil || *lastTxTo != validatorCoinbase {
-			log.Error("last transaction is not to the proposer!", "err", err, "lastTx", lastTx)
-			return nil, errors.New("last transaction is not proposer payment")
-		}
-	
-		block.Profit.Set(lastTx.Value())
-		log.Info("Block finalized and assembled", "blockProfit", block.Profit.String(), "proposer payment tx", lastTx, "receipt", receipt)
+	if params.noTxs {
+		return block, nil
 	}
+
+	if len(work.txs) == 0 {
+		return nil, errors.New("no proposer payment tx")
+	} else if len(work.receipts) == 0 {
+		return nil, errors.New("no proposer payment receipt")
+	}
+
+	lastTx := work.txs[len(work.txs)-1]
+	receipt := work.receipts[len(work.receipts)-1]
+	if receipt.TxHash != lastTx.Hash() || receipt.Status != types.ReceiptStatusSuccessful {
+		log.Error("proposer payment not successful!", "lastTx", lastTx, "receipt", receipt)
+		return nil, errors.New("last transaction is not proposer payment")
+	}
+	lastTxTo := lastTx.To()
+	if lastTxTo == nil || *lastTxTo != validatorCoinbase {
+		log.Error("last transaction is not to the proposer!", "err", err, "lastTx", lastTx)
+		return nil, errors.New("last transaction is not proposer payment")
+	}
+
+	block.Profit.Set(lastTx.Value())
+	log.Info("Block finalized and assembled", "blockProfit", block.Profit.String(), "proposer payment tx", lastTx, "receipt", receipt)
+
 	return block, nil
 }
 


### PR DESCRIPTION
As the builder expects every block to be mev-boosted, it expects a proposer payment in the block which break compatibility serving as a local execution client. If the EL requests an empty block to be build, it should skip proposer payment checks.